### PR TITLE
Implement MangaFire API

### DIFF
--- a/src/MangaFire/MangaFire.d.ts
+++ b/src/MangaFire/MangaFire.d.ts
@@ -3,4 +3,27 @@ declare namespace MangaFire {
     offset?: number;
     collectedIds?: string[];
   }
+  interface Result{
+    status: number,
+    result: {
+      html: string,
+      title_format: string;
+    },
+  }
+
+  interface PageResponse {
+    status: number;
+    result: {
+      images: ImageData[];
+    };
+  }
+  
+  // Represents each image entry in the "images" array
+  // Each entry is an array where:
+  // - index 0 is a string (image URL)
+  // - index 1 is a number (possibly an identifier or category)
+  // - index 2 is a number (possibly a flag or status indicator)
+  type ImageData = [string, number, number];
+
+  
 }


### PR DESCRIPTION
Implementation of the MangaFire API in the extension, feel free to rework what I have, this is just a basic implementation that doesn't include date or title parsing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for MangaFire data structures
	- Updated chapter and image data retrieval methods

- **Improvements**
	- Transitioned to more robust AJAX-based data fetching
	- Improved parsing of manga chapter and image information

- **Technical Updates**
	- Refined data handling for more accurate manga source interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->